### PR TITLE
Fix whitespace remover

### DIFF
--- a/src/version_prefix.rs
+++ b/src/version_prefix.rs
@@ -38,7 +38,7 @@ where
             self.0.has_seen_version = true;
             let mut new_buf = vec![0; buf.len() + 1];
             new_buf[0] = self.0.version;
-            (&mut new_buf[1..]).copy_from_slice(buf);
+            new_buf[1..].copy_from_slice(buf);
             self.0.wrapped.write(&new_buf).map(|n| n - 1)
         }
     }

--- a/src/whitespace_remover/test.rs
+++ b/src/whitespace_remover/test.rs
@@ -1,0 +1,33 @@
+use std::io::Read;
+
+#[test]
+fn test() {
+    const TEST: &str = " t/prau0INWoWUQ0LgQ\tMUdJRcCetBZP\nAyD+DCpn 01yWZT/LBo3Ogk0INwwuAtKNI ";
+
+    let mut stripped = String::new();
+    super::WhitespaceRemover::new(TEST.as_bytes())
+        .read_to_string(&mut stripped)
+        .unwrap();
+
+    assert_eq!(
+        stripped,
+        "t/prau0INWoWUQ0LgQMUdJRcCetBZPAyD+DCpn01yWZT/LBo3Ogk0INwwuAtKNI"
+    );
+}
+
+#[test]
+fn long_whitespace() {
+    let mut test_string = "a".to_owned();
+    test_string.reserve_exact(161);
+    for _ in 0..20 {
+        test_string.push_str("        ");
+    }
+    test_string.push('b');
+
+    let mut stripped = String::new();
+    super::WhitespaceRemover::new(test_string.as_bytes())
+        .read_to_string(&mut stripped)
+        .unwrap();
+
+    assert_eq!(stripped, "ab");
+}


### PR DESCRIPTION
Previously, if there was enough whitespace to fill the buffer it would return a read length of zero, even though there is still content to read. This will cause consumers to assume they have read the entire content.