### PR TITLE
Revert to `Connection = ConnectionPoint`

### DIFF
--- a/src/objects.rs
+++ b/src/objects.rs
@@ -584,12 +584,7 @@ pub struct Position {
 }
 
 /// https://wiki.factorio.com/Blueprint_string_format#Connection_object
-#[derive(Debug, PartialEq, Eq, Clone, Deserialize, Serialize)]
-#[serde(untagged)]
-pub enum Connection {
-    Single(ConnectionPoint),
-    Multiple(Vec<ConnectionData>),
-}
+pub type Connection = ConnectionPoint;
 
 /// https://wiki.factorio.com/Blueprint_string_format#Connection_point_object
 #[derive(Debug, PartialEq, Eq, Clone, Deserialize, Serialize)]


### PR DESCRIPTION
Commit 1a939c2df3a1e100c82f064a33f7c8043c1b9805 changed the `Connection`type from

```rust
pub type Connection = ConnectionPoint;
```

to

```rust
#[derive(Debug, PartialEq, Eq, Clone, Deserialize, Serialize)]
#[serde(untagged)]
pub enum Connection {
    Single(ConnectionPoint),
    Multiple(Vec<ConnectionData>),
}
```

I find this change rather confusing as a user of this library. Why is a multiply connecton a vector of something different from when I have a single connection? Futhermore, how do i know the type of wire the `Multiple` connection is talking about?

Because of this confusion i think it is best to revert this change.